### PR TITLE
Update `pyproject.toml` to conditionally include `cuda-python` dependency for MacOS

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "PyOpenGL",
     "websockets",
     "glfw",
-    "cuda-python"
+    "cuda-python; sys_platform != 'darwin'"
 ]
 
 [project.urls]


### PR DESCRIPTION
Exclude `cuda-python` from installation on macOS.